### PR TITLE
Expand PHP cipher library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: php-actions/composer@v6
+        with:
+          php_extensions: mbstring
+      - run: composer install --prefer-dist --no-progress
+      - run: composer test
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+- Added `CipherInterface` and updated `Cipher` to implement it.
+- Added support for AES-256-GCM and optional HMAC with AES-256-CBC.
+- Configuration via constructor or environment variables.
+- Simple CLI tool for encryption/decryption.
+- File encryption helper methods.
+- Extended test suite and added GitHub Actions CI workflow.
+- Updated documentation.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cipher
 
-A simple PHP library to encrypt and decrypt strings using AES-256-CBC. The library provides a lightweight wrapper around `openssl` and requires PHP 8.1 or higher.
+A simple PHP library to encrypt and decrypt strings. The library supports `AES-256-CBC` and `AES-256-GCM` and requires PHP 8.1 or higher.
 
 ## Installation
 
@@ -19,6 +19,40 @@ $cipher = new Cipher('YourSecretKey');
 
 $encrypted = $cipher->encrypt('message');
 $decrypted = $cipher->decrypt($encrypted);
+```
+
+### Using environment variables
+
+You can provide the key and cipher method through environment variables:
+
+```bash
+export CIPHER_KEY=mysecret
+export CIPHER_METHOD=AES-256-GCM
+```
+
+```php
+$cipher = new Cipher();
+```
+
+### CLI
+
+This repository ships with a small CLI tool. Encrypt a string:
+
+```bash
+bin/cipher --encrypt "hello" --key mysecret
+```
+
+Decrypt a string:
+
+```bash
+bin/cipher --decrypt "<ciphertext>" --key mysecret
+```
+
+### File encryption
+
+```php
+$cipher->encryptFile('input.txt', 'output.enc');
+$cipher->decryptFile('output.enc', 'plain.txt');
 ```
 
 ## Running Tests

--- a/bin/cipher
+++ b/bin/cipher
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+require __DIR__.'/../vendor/autoload.php';
+
+use peterurk\Cipher\Cipher;
+
+$options = getopt('', ['encrypt::', 'decrypt::', 'key::', 'method::', 'hmac']);
+$key = $options['key'] ?? getenv('CIPHER_KEY');
+$method = $options['method'] ?? 'AES-256-CBC';
+$useHmac = isset($options['hmac']);
+
+if ($key === false || $key === '') {
+    fwrite(STDERR, "A key is required via --key or CIPHER_KEY\n");
+    exit(1);
+}
+
+$cipher = new Cipher($key, $method, $useHmac);
+
+if (isset($options['encrypt'])) {
+    $input = $options['encrypt'] !== false ? $options['encrypt'] : stream_get_contents(STDIN);
+    echo $cipher->encrypt($input) . PHP_EOL;
+    exit(0);
+}
+
+if (isset($options['decrypt'])) {
+    $input = $options['decrypt'] !== false ? $options['decrypt'] : stream_get_contents(STDIN);
+    echo $cipher->decrypt($input) . PHP_EOL;
+    exit(0);
+}
+
+fwrite(STDERR, "Usage: cipher --encrypt <text>|--decrypt <text> [--key <key>] [--method <method>] [--hmac]\n");
+exit(1);
+

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
             "peterurk\\Cipher\\Tests\\": "tests/"
         }
     },
+    "bin": ["bin/cipher"],
     "scripts": {
         "test": "phpunit"
     },

--- a/src/Cipher.php
+++ b/src/Cipher.php
@@ -11,13 +11,15 @@ use RuntimeException;
  *
  * @author Peter Post <peterurk@gmail.com>
  */
-final class Cipher
+final class Cipher implements CipherInterface
 {
 
     /**
      * SHA256 Encrypted key
      */
     private string $encryptionKey;
+    private string $method;
+    private bool $useHmac;
 
     /**
      * Constructor
@@ -26,13 +28,21 @@ final class Cipher
      *
      * @throws InvalidArgumentException When the provided key is empty
      */
-    public function __construct(string $personalKey)
+    public function __construct(?string $personalKey = null, ?string $method = null, bool $useHmac = false)
     {
-        if ($personalKey === '') {
+        $personalKey = $personalKey ?? getenv('CIPHER_KEY');
+        if ($personalKey === false || $personalKey === '') {
             throw new InvalidArgumentException('A personal key is required for encryption/decryption');
         }
 
         $this->encryptionKey = hash('sha256', $personalKey, true);
+
+        $this->method = $method ?? getenv('CIPHER_METHOD') ?: 'AES-256-CBC';
+        if (!in_array($this->method, openssl_get_cipher_methods(), true)) {
+            throw new InvalidArgumentException('Unsupported cipher method');
+        }
+
+        $this->useHmac = $useHmac;
     }
 
     /**
@@ -43,12 +53,25 @@ final class Cipher
      */
     public function encrypt(string $input): string
     {
-        $ivLength = openssl_cipher_iv_length('AES-256-CBC');
+        $ivLength = openssl_cipher_iv_length($this->method);
         $iv = openssl_random_pseudo_bytes($ivLength);
-        $cipher = openssl_encrypt($input, 'AES-256-CBC', $this->encryptionKey, OPENSSL_RAW_DATA, $iv);
+        if ($this->method === 'AES-256-GCM') {
+            $cipher = openssl_encrypt($input, $this->method, $this->encryptionKey, OPENSSL_RAW_DATA, $iv, $tag);
+            if ($cipher === false) {
+                throw new RuntimeException('Encryption failed');
+            }
+            return base64_encode($iv . $tag . $cipher);
+        }
+
+        $cipher = openssl_encrypt($input, $this->method, $this->encryptionKey, OPENSSL_RAW_DATA, $iv);
 
         if ($cipher === false) {
             throw new RuntimeException('Encryption failed');
+        }
+
+        if ($this->useHmac) {
+            $hmac = hash_hmac('sha256', $iv . $cipher, $this->encryptionKey, true);
+            return base64_encode($iv . $hmac . $cipher);
         }
 
         return base64_encode($iv . $cipher);
@@ -67,17 +90,60 @@ final class Cipher
             throw new InvalidArgumentException('Input is not valid base64');
         }
 
-        $ivLength = openssl_cipher_iv_length('AES-256-CBC');
+        $ivLength = openssl_cipher_iv_length($this->method);
         $iv = substr($raw, 0, $ivLength);
-        $ciphertext = substr($raw, $ivLength);
-
-        $plain = openssl_decrypt($ciphertext, 'AES-256-CBC', $this->encryptionKey, OPENSSL_RAW_DATA, $iv);
+        $offset = $ivLength;
+        if ($this->method === 'AES-256-GCM') {
+            $tagLength = 16;
+            $tag = substr($raw, $offset, $tagLength);
+            $offset += $tagLength;
+            $ciphertext = substr($raw, $offset);
+            $plain = openssl_decrypt($ciphertext, $this->method, $this->encryptionKey, OPENSSL_RAW_DATA, $iv, $tag);
+        } else {
+            if ($this->useHmac) {
+                $hmacLength = 32;
+                $hmac = substr($raw, $offset, $hmacLength);
+                $offset += $hmacLength;
+                $ciphertext = substr($raw, $offset);
+                $calculated = hash_hmac('sha256', $iv . $ciphertext, $this->encryptionKey, true);
+                if (!hash_equals($hmac, $calculated)) {
+                    throw new RuntimeException('HMAC verification failed');
+                }
+            } else {
+                $ciphertext = substr($raw, $offset);
+            }
+            $plain = openssl_decrypt($ciphertext, $this->method, $this->encryptionKey, OPENSSL_RAW_DATA, $iv);
+        }
 
         if ($plain === false) {
             throw new RuntimeException('Decryption failed');
         }
 
         return $plain;
+    }
+
+    public function encryptFile(string $inputPath, string $outputPath): void
+    {
+        $data = file_get_contents($inputPath);
+        if ($data === false) {
+            throw new RuntimeException('Unable to read input file');
+        }
+        $encrypted = $this->encrypt($data);
+        if (file_put_contents($outputPath, $encrypted) === false) {
+            throw new RuntimeException('Unable to write output file');
+        }
+    }
+
+    public function decryptFile(string $inputPath, string $outputPath): void
+    {
+        $data = file_get_contents($inputPath);
+        if ($data === false) {
+            throw new RuntimeException('Unable to read input file');
+        }
+        $plain = $this->decrypt($data);
+        if (file_put_contents($outputPath, $plain) === false) {
+            throw new RuntimeException('Unable to write output file');
+        }
     }
 }
 

--- a/src/CipherInterface.php
+++ b/src/CipherInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace peterurk\Cipher;
+
+interface CipherInterface
+{
+    public function encrypt(string $input): string;
+    public function decrypt(string $input): string;
+}

--- a/tests/CipherTest.php
+++ b/tests/CipherTest.php
@@ -15,6 +15,20 @@ final class CipherTest extends TestCase
         $this->assertSame('hello', $cipher->decrypt($encrypted));
     }
 
+    public function testEncryptAndDecryptGcm(): void
+    {
+        $cipher = new Cipher('secret', 'AES-256-GCM');
+        $encrypted = $cipher->encrypt('gcm');
+        $this->assertSame('gcm', $cipher->decrypt($encrypted));
+    }
+
+    public function testEncryptAndDecryptWithHmac(): void
+    {
+        $cipher = new Cipher('secret', 'AES-256-CBC', true);
+        $encrypted = $cipher->encrypt('hmac');
+        $this->assertSame('hmac', $cipher->decrypt($encrypted));
+    }
+
     public function testInvalidKey(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary
- add CipherInterface and implement in Cipher
- support AES-256-GCM and optional HMAC with AES-256-CBC
- allow configuration through environment variables
- add CLI tool and file encryption helpers
- set up GitHub Actions workflow and update docs
- extend tests and add changelog

## Testing
- `composer install` *(fails: composer not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405cd43af08325a0db8620d3570c49